### PR TITLE
Palette mixin for setting "theme" properties

### DIFF
--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -24,6 +24,8 @@ $export-ui-classes: true !default;
   display: flex;
 }
 
+// Default Palette Settings
+// =============================================================================
 @include palette-set('primary', color('sea-green'));
 @include palette-set('menu', color('white'));
 @include palette-set('selected', color('white'));

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -1,13 +1,14 @@
-@import "core/animation";
-@import "core/bem";
-@import "core/breakpoints";
-@import "core/color";
-@import "core/grid";
-@import "core/functions";
-@import "core/spacing";
-@import "core/typography";
-@import "core/quicksand";
-@import "core/normalize";
+@import 'core/animation';
+@import 'core/bem';
+@import 'core/breakpoints';
+@import 'core/color';
+@import 'core/palette';
+@import 'core/grid';
+@import 'core/functions';
+@import 'core/spacing';
+@import 'core/typography';
+@import 'core/quicksand';
+@import 'core/normalize';
 
 $export-ui-classes: true !default;
 
@@ -23,84 +24,25 @@ $export-ui-classes: true !default;
   display: flex;
 }
 
-// Default Color Swatches
-// =============================================================================
-// Primary
-@include color-set('nc-coral', #E2215B); // node color
-@include color-set('mustard', #F2B700); // connection color
-@include color-set('mustard--dark', #DBA500);
-@include color-set('sea-green', #00C9A2); // primary action color
-@include color-set('white', #FFFFFF); // type / selected color
-@include color-set('slate-blue', #6B72EC); // settings color
-@include color-set('navy-taupe', #2D2955); // background
-@include color-set('cyber-grape', #3A3A75); // light background
-@include color-set('rich-black', #16152B); // dark background
-@include color-set('charcoal', #6D6F76); // text / deselected color
-@include color-set('platinum', #F2F6F7); // panel background color
-@include color-set('platinum--dark', #DAE3E5); // divider color
-@include color-set('white', #FFFFFF);
+@include palette-set('primary', color('sea-green'));
+@include palette-set('menu', color('white'));
+@include palette-set('selected', color('white'));
+@include palette-set('settings', color('slate-blue'));
+@include palette-set('background', color('navy-taupe'));
+@include palette-set('text', color('white'));
+@include palette-set('tex-muted', color('cyber-grape'));
+@include palette-set('link', color('nc-coral'));
+@include palette-set('light-background', color('cyber-grape'));
+@include palette-set('dark-background', color('rich-black'));
+@include palette-set('headings', color('white'));
+@include palette-set('menu-headings', color('charcoal'));
+@include palette-set('divider', color('platinum--dark'));
 
-// Secondary
-@include color-set('sea-serpent', #0FB2E2);
-@include color-set('sea-serpent--dark', #0FA3CE);
-@include color-set('purple-pizazz', #D30FEF);
-@include color-set('purple-pizazz--dark', #BF0CD8);
-@include color-set('paradise-pink', #FF3A8C);
-@include color-set('paradise-pink--dark', #E8357C);
-@include color-set('cerulean-blue', #0F70FF);
-@include color-set('cerulean-blue--dark', #0F66E8);
-@include color-set('kiwi', #70BF54);
-@include color-set('kiwi--dark', #66AD4C);
+@include palette-set('node-base', color('network-canvas-coral'));
+@include palette-set('node-dark', darken(color('network-canvas-coral'), 5%));
 
-
-// Tertiary
-@include color-set('neon-carrot', #F7891E);
-@include color-set('neon-carrot--dark', #E07C1C);
-@include color-set('barbie-pink', #ED008C);
-@include color-set('barbie-pink--dark', #D6007F);
-@include color-set('tomato', #E82D3F);
-@include color-set('tomato--dark', #D32B3A);
-
-$roles: (
-  'node': color('network-canvas-coral'),
-  'edge': color('mustard'),
-  'primary': color('sea-green'),
-  'menu': color('white'),
-  'selected': color('white'),
-  'settings': color('slate-blue'),
-  'background': color('navy-taupe'),
-  'text': color('white'),
-  'tex-muted': color('cyber-grape'),
-  'link': color('nc-coral'),
-  'light-background': color('cyber-grape'),
-  'dark-background': color('rich-black'),
-  'headings': color('white'),
-  'menu-headings': color('charcoal'),
-  'divider': color('platinum--dark')
-);
-
-// Collections
-$nodes: (
-  default: (
-    base:   map-get($roles, node),
-    dark:   darken(map-get($roles, node), 5%)
-  )
-);
-
-$edges: (
-  default: (
-    base:   map-get($roles, edge),
-    dark:   darken(map-get($roles, edge), 5%)
-  )
-);
-
-@function node-palette($palette: 'default', $tone: 'base') {
-  @return map-get(map-get($nodes, $palette), $tone);
-}
-
-@function palette($role) {
-  @return map-get($roles, $role);
-}
+@include palette-set('edge-base', color('mustard'));
+@include palette-set('edge-dark', darken(color('mustard'), 5%));
 
 // Default Copy Typography Sizes
 // =============================================================================

--- a/src/styles/global/core/_color.scss
+++ b/src/styles/global/core/_color.scss
@@ -1,16 +1,18 @@
+// sass-lint:disable no-warn
+
 // Color setter and mixins
 // =============================================================================
 $-color-map: () !default;
-$-color-alpha-map: (0.1, 0.15, 0.3, 0.6, 0.8, 1) !default;
+$-color-alpha-map: (.1, .15, .3, .6, .8, 1) !default;
 
 @mixin color-set($color-name, $color-value) {
   $-color-map: map-merge($-color-map, ($color-name: $color-value)) !global;
 }
 
 @function color($color-name, $alpha: 1) {
-  $color: #FFFFFF;
-  @if index($-color-alpha-map, $alpha)==null {
-    @warn "color: Only use #{$-color-map-alpha} for alpha values.";
+  $color: #fff;
+  @if index($-color-alpha-map, $alpha) == null {
+    @warn 'color: Only use #{$-color-map-alpha} for alpha values.';
   }
   @if map-has-key($-color-map, $color-name) {
     $color: map-get($-color-map, $color-name);
@@ -27,9 +29,47 @@ $-color-alpha-map: (0.1, 0.15, 0.3, 0.6, 0.8, 1) !default;
 
       @if $include-hover {
         &:hover {
-          background-color: color($color-name, 0.8);
+          background-color: color($color-name, .8);
         }
       }
     }
   }
 }
+
+
+// Default Color Swatches
+// =============================================================================
+// Primary
+@include color-set('nc-coral', #e2215b); // node color
+@include color-set('mustard', #f2b700); // connection color
+@include color-set('mustard--dark', #dba500);
+@include color-set('sea-green', #00c9a2); // primary action color
+@include color-set('white', #fff); // type / selected color
+@include color-set('slate-blue', #6b72ec); // settings color
+@include color-set('navy-taupe', #2d2955); // background
+@include color-set('cyber-grape', #3a3a75); // light background
+@include color-set('rich-black', #16152b); // dark background
+@include color-set('charcoal', #6d6f76); // text / deselected color
+@include color-set('platinum', #f2f6f7); // panel background color
+@include color-set('platinum--dark', #dae3e5); // divider color
+@include color-set('white', #fff);
+
+// secondary
+@include color-set('sea-serpent', #0fb2e2);
+@include color-set('sea-serpent--dark', #0fa3ce);
+@include color-set('purple-pizazz', #d30fef);
+@include color-set('purple-pizazz--dark', #bf0cd8);
+@include color-set('paradise-pink', #ff3a8c);
+@include color-set('paradise-pink--dark', #e8357c);
+@include color-set('cerulean-blue', #0f70ff);
+@include color-set('cerulean-blue--dark', #0f66e8);
+@include color-set('kiwi', #70bf54);
+@include color-set('kiwi--dark', #66ad4c);
+
+// tertiary
+@include color-set('neon-carrot', #f7891e);
+@include color-set('neon-carrot--dark', #e07c1c);
+@include color-set('barbie-pink', #ed008c);
+@include color-set('barbie-pink--dark', #d6007f);
+@include color-set('tomato', #e82d3f);
+@include color-set('tomato--dark', #d32b3a);

--- a/src/styles/global/core/_palette.scss
+++ b/src/styles/global/core/_palette.scss
@@ -1,0 +1,11 @@
+// Paletee setter and mixins
+// =============================================================================
+$-palette-map: () !default;
+
+@mixin palette-set($palette-name, $palette-value) {
+  $-palette-map: map-merge($-palette-map, ($palette-name: $palette-value)) !global;
+}
+
+@function palette($palette-name) {
+  @return map-get($-palette-map, $palette-name);
+}


### PR DESCRIPTION
Follow the convention of `color-set`, for new `palette-set` mixin which acts as a repository for mapping colors to a "theme".