### PR TITLE
Fix variable name in warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-ui",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "scripts": {

--- a/src/styles/global/core/_color.scss
+++ b/src/styles/global/core/_color.scss
@@ -12,7 +12,7 @@ $-color-alpha-map: (.1, .15, .3, .6, .7, .8, 1) !default;
 @function color($color-name, $alpha: 1) {
   $color: #fff;
   @if index($-color-alpha-map, $alpha) == null {
-    @warn 'color: Only use #{$-color-map-alpha} for alpha values.';
+    @warn 'color: Only use #{$-color-alpha-map} for alpha values.';
   }
   @if map-has-key($-color-map, $color-name) {
     $color: map-get($-color-map, $color-name);


### PR DESCRIPTION
Fixes a variable name used to warn at compile time. Currently, the build halts with an 'undefined variable' error.

Note that the typical dev workflow (`npm start`) in `Network-Canvas` overwrites warnings with the server start message, making `@warn` less obvious (but I've left as `@warn` regardless). 