### PR TITLE
input tweaks

### DIFF
--- a/lib/styles/components/inputs.scss
+++ b/lib/styles/components/inputs.scss
@@ -249,6 +249,15 @@
     @include reset-input;
     cursor: pointer;
 
+    &-group__container {
+      margin: 3em 0;
+      position: relative;
+
+      .input__tooltip-right .input__error {
+        top: -4rem;
+      }
+    }
+
     &__container {
       position: relative;
     }
@@ -320,6 +329,8 @@
     }
 
     &__container {
+      margin: 3em 0;
+
       position: relative;
       padding-right: 1em;
       .input__label {
@@ -333,7 +344,7 @@
       height: $toggle-height * .5;
       width: $switch-size * 1.5;
       position: relative;
-      margin: .5em .75em;
+      margin: .5em 1em;
     }
 
     &__button {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-ui",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "scripts": {

--- a/src/styles/components/inputs.scss
+++ b/src/styles/components/inputs.scss
@@ -249,6 +249,15 @@
     @include reset-input;
     cursor: pointer;
 
+    &-group__container {
+      margin: 3em 0;
+      position: relative;
+
+      .input__tooltip-right .input__error {
+        top: -4rem;
+      }
+    }
+
     &__container {
       position: relative;
     }
@@ -320,6 +329,8 @@
     }
 
     &__container {
+      margin: 3em 0;
+
       position: relative;
       padding-right: 1em;
       .input__label {
@@ -333,7 +344,7 @@
       height: $toggle-height * .5;
       width: $switch-size * 1.5;
       position: relative;
-      margin: .5em .75em;
+      margin: .5em 1em;
     }
 
     &__button {


### PR DESCRIPTION
This better positions the error message for a radio group so it can be seen, and gives a slightly higher margin to the toggle button so it isn't cut off in forms. Fixes codaco/Network-Canvas#378.  Also fixes codaco/Network-Canvas#374.

To check, load the "teaching" protocol in the main app, and click the "new node" button on a name generator stage. Try to submit without filling it in, and the radio group should display an error now.