### PR TITLE
Feature/header styles

### DIFF
--- a/lib/styles/global/_default.scss
+++ b/lib/styles/global/_default.scss
@@ -30,17 +30,21 @@ $export-ui-classes: true !default;
 
 $line-height-base: 1.5 !default;
 
-$netcanvas-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$display-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$system-font-family: 'system-ui', sans-serif;
+
+$netcanvas-font-family: $system-font-family !default;
 $netcanvas-font-size: 18px;
 
-$headings-font-family:   inherit !default;
-$headings-font-weight:   400 !default;
-$headings-line-height:   1.1 !default;
+$headings-primary-font-family: $display-font-family !default;
+$headings-font-family: inherit !default;
+$headings-font-weight: 400 !default;
+$headings-line-height: 1.1 !default;
 
 @include type-set(
   'quicksand', base,
   (
-    font-family: 'Quicksand, "Open Sans", sans-serif',
+    font-family: $display-font-family,
     font-size: 16px,
     line-height: $line-height-base,
     font-weight: $headings-font-weight
@@ -62,6 +66,7 @@ $headings-line-height:   1.1 !default;
 @include type-set(
   'main-title', base,
   (
+    font-family: $headings-primary-font-family,
     font-size: 45px,
     line-height: 1.429,
     font-weight: 700,
@@ -72,6 +77,7 @@ $headings-line-height:   1.1 !default;
 @include type-set(
   'title-1', base,
   (
+    font-family: $headings-primary-font-family,
     font-size: 32px,
     line-height: 1.429,
     font-weight: 700,
@@ -157,26 +163,27 @@ html {
 // Headings
 
 // Based of px sizes in style guide (em values were inconsistent)
-$text-sizes: (
-  h1: 1.75rem,
-  h2: 1.25rem,
-  h3: 1.0625rem,
-  h4: 1rem,
-  h5: .75rem,
+$headings: (
+  h1: (1.75rem, $headings-primary-font-family),
+  h2: (1.25rem, $headings-font-family),
+  h3: (1.0625rem, $headings-font-family),
+  h4: (1rem, $headings-font-family),
+  h5: (.75rem, $headings-font-family),
 );
 
-@mixin text($text-size) {
-  font-family: $headings-font-family;
-  font-size: map-get($text-sizes, $text-size);
+@mixin text($font-size, $font-family) {
+  font-family: $font-family;
+  font-size: $font-size;
   font-weight: $headings-font-weight;
   letter-spacing: .05rem;
   line-height: $headings-line-height;
 }
 
-@each $text-size in $text-sizes {
-  $text-size-name: nth($text-size, 1);
+@each $heading-tag, $heading-properties in $headings {
+  #{$heading-tag} {
+    $font-size: nth($heading-properties, 1);
+    $font-family: nth($heading-properties, 2);
 
-  #{$text-size-name} {
-    @include text($text-size-name);
+    @include text($font-size, $font-family);
   }
 }

--- a/lib/styles/global/_default.scss
+++ b/lib/styles/global/_default.scss
@@ -28,8 +28,12 @@ $export-ui-classes: true !default;
 // Default Copy Typography Sizes
 // =============================================================================
 
-$netcanvas-font-size: 16px;
 $line-height-base: 1.5 !default;
+
+$netcanvas-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$netcanvas-font-size: 18px;
+
+$headings-font-family:   inherit !default;
 $headings-font-weight:   400 !default;
 $headings-line-height:   1.1 !default;
 
@@ -145,20 +149,12 @@ $headings-line-height:   1.1 !default;
   @include grid-classes;
 }
 
-$netcanvas-font-family: 'Quicksand', 'Open Sans', sans serif;
-$netcanvas-font-size: 18px;
-$line-height-base: 1.5 !default;
-
 html {
   font-family: $netcanvas-font-family;
   font-size: $netcanvas-font-size;
 }
 
 // Headings
-
-$headings-font-family:   inherit !default;
-$headings-line-height:   1.1 !default;
-$headings-color:         inherit !default;
 
 // Based of px sizes in style guide (em values were inconsistent)
 $text-sizes: (

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -30,17 +30,21 @@ $export-ui-classes: true !default;
 
 $line-height-base: 1.5 !default;
 
-$netcanvas-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$display-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$system-font-family: 'system-ui', sans-serif;
+
+$netcanvas-font-family: $system-font-family !default;
 $netcanvas-font-size: 18px;
 
-$headings-font-family:   inherit !default;
-$headings-font-weight:   400 !default;
-$headings-line-height:   1.1 !default;
+$headings-primary-font-family: $display-font-family !default;
+$headings-font-family: inherit !default;
+$headings-font-weight: 400 !default;
+$headings-line-height: 1.1 !default;
 
 @include type-set(
   'quicksand', base,
   (
-    font-family: 'Quicksand, "Open Sans", sans-serif',
+    font-family: $display-font-family,
     font-size: 16px,
     line-height: $line-height-base,
     font-weight: $headings-font-weight
@@ -62,6 +66,7 @@ $headings-line-height:   1.1 !default;
 @include type-set(
   'main-title', base,
   (
+    font-family: $headings-primary-font-family,
     font-size: 45px,
     line-height: 1.429,
     font-weight: 700,
@@ -72,6 +77,7 @@ $headings-line-height:   1.1 !default;
 @include type-set(
   'title-1', base,
   (
+    font-family: $headings-primary-font-family,
     font-size: 32px,
     line-height: 1.429,
     font-weight: 700,
@@ -157,26 +163,27 @@ html {
 // Headings
 
 // Based of px sizes in style guide (em values were inconsistent)
-$text-sizes: (
-  h1: 1.75rem,
-  h2: 1.25rem,
-  h3: 1.0625rem,
-  h4: 1rem,
-  h5: .75rem,
+$headings: (
+  h1: (1.75rem, $headings-primary-font-family),
+  h2: (1.25rem, $headings-font-family),
+  h3: (1.0625rem, $headings-font-family),
+  h4: (1rem, $headings-font-family),
+  h5: (.75rem, $headings-font-family),
 );
 
-@mixin text($text-size) {
-  font-family: $headings-font-family;
-  font-size: map-get($text-sizes, $text-size);
+@mixin text($font-size, $font-family) {
+  font-family: $font-family;
+  font-size: $font-size;
   font-weight: $headings-font-weight;
   letter-spacing: .05rem;
   line-height: $headings-line-height;
 }
 
-@each $text-size in $text-sizes {
-  $text-size-name: nth($text-size, 1);
+@each $heading-tag, $heading-properties in $headings {
+  #{$heading-tag} {
+    $font-size: nth($heading-properties, 1);
+    $font-family: nth($heading-properties, 2);
 
-  #{$text-size-name} {
-    @include text($text-size-name);
+    @include text($font-size, $font-family);
   }
 }

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -28,8 +28,12 @@ $export-ui-classes: true !default;
 // Default Copy Typography Sizes
 // =============================================================================
 
-$netcanvas-font-size: 16px;
 $line-height-base: 1.5 !default;
+
+$netcanvas-font-family: 'Quicksand', 'Open Sans', sans-serif;
+$netcanvas-font-size: 18px;
+
+$headings-font-family:   inherit !default;
 $headings-font-weight:   400 !default;
 $headings-line-height:   1.1 !default;
 
@@ -145,20 +149,12 @@ $headings-line-height:   1.1 !default;
   @include grid-classes;
 }
 
-$netcanvas-font-family: 'Quicksand', 'Open Sans', sans serif;
-$netcanvas-font-size: 18px;
-$line-height-base: 1.5 !default;
-
 html {
   font-family: $netcanvas-font-family;
   font-size: $netcanvas-font-size;
 }
 
 // Headings
-
-$headings-font-family:   inherit !default;
-$headings-line-height:   1.1 !default;
-$headings-color:         inherit !default;
 
 // Based of px sizes in style guide (em values were inconsistent)
 $text-sizes: (


### PR DESCRIPTION
See https://github.com/codaco/Server/issues/48.

> Our desktop apps should use the system font of the host platform for body text, reserving our Network Canvas font stack (Quicksand) for headings, and marquee text.

This updates the body text to use [system-ui](https://www.chromestatus.com/feature/5640395337760768). I tested Electron Mac+Win, Android, and iOS.

RFC: Since header styling was already applied through tags (h1-h5), I added this in the same way. However, since the intent is to use headers for specific purposes (based on existing comments like `// H2 - Form question headlines, buttons, text links` and implementation), I added the display font only to H1s. We could instead rely on modifier classes for display text (which is supported by this css), but that will take some more work in the app.

Note: no version changes made yet.