### PR TITLE
Include normalize before other rules are applied

### DIFF
--- a/lib/styles/global/_default.scss
+++ b/lib/styles/global/_default.scss
@@ -25,6 +25,10 @@ $export-ui-classes: true !default;
   display: flex;
 }
 
+@if $export-ui-classes {
+  @include normalize;
+}
+
 // Default Copy Typography Sizes
 // =============================================================================
 
@@ -183,7 +187,6 @@ $headings: (
 );
 
 @if $export-ui-classes {
-  @include normalize;
   @include typography-classes;
   @include grid-classes;
 }

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -25,6 +25,10 @@ $export-ui-classes: true !default;
   display: flex;
 }
 
+@if $export-ui-classes {
+  @include normalize;
+}
+
 // Default Copy Typography Sizes
 // =============================================================================
 
@@ -183,7 +187,6 @@ $headings: (
 );
 
 @if $export-ui-classes {
-  @include normalize;
   @include typography-classes;
   @include grid-classes;
 }


### PR DESCRIPTION
Fixes #42.

I'm not entirely sure what the purpose of `$export-ui-classes` is, but I think this is the intended behavior: normalize comes before any other applied styles. I left the other 'export classes' in the same place.