### PR TITLE
Do not re-include files that output CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,14 @@ const LocalComponent = props => (
 
 ### Styles
 
-You can also webpack the corresponding styles with:
-
-```js
-// in LocalComponent.js
-
-import '~network-canvas-ui/lib/styles/example-component';
-```
-
-Or alternatively include all styles in your main stylesheet and add the mixins you want out of the box:
+You can include all styles in your main stylesheet:
 
 ```scss
 // in main.scss
-
 @import '~network-canvas-ui/lib/styles/all';
-
-// optional mixin classes
-@include reset;
-@include type-classes;
-@include button;
-@include icon;
-@include input;
 ```
+
+Importing styles for only certain components may work but is not supported at this time.
 
 ### Icons
 

--- a/lib/styles/components/button.scss
+++ b/lib/styles/components/button.scss
@@ -1,8 +1,6 @@
 // Button
 // =============================================================================
 
-@import "../global/default";
-
 @mixin reset-button {
   -webkit-appearance: none;
   border: 0;

--- a/lib/styles/components/icons.scss
+++ b/lib/styles/components/icons.scss
@@ -1,8 +1,6 @@
 // Icons
 // =============================================================================
 
-@import "../global/default";
-
 $icon-dimension-base: 35px !default;
 
 $icon-small-width: $icon-dimension-base !default;

--- a/lib/styles/components/inputs.scss
+++ b/lib/styles/components/inputs.scss
@@ -1,8 +1,6 @@
 // Inputs
 // =============================================================================
 
-@import "../global/default";
-
 @mixin reset-input {
   position: absolute;
   top: 0;

--- a/src/styles/components/button.scss
+++ b/src/styles/components/button.scss
@@ -1,8 +1,6 @@
 // Button
 // =============================================================================
 
-@import "../global/default";
-
 @mixin reset-button {
   -webkit-appearance: none;
   border: 0;

--- a/src/styles/components/icons.scss
+++ b/src/styles/components/icons.scss
@@ -1,8 +1,6 @@
 // Icons
 // =============================================================================
 
-@import "../global/default";
-
 $icon-dimension-base: 35px !default;
 
 $icon-small-width: $icon-dimension-base !default;

--- a/src/styles/components/inputs.scss
+++ b/src/styles/components/inputs.scss
@@ -1,8 +1,6 @@
 // Inputs
 // =============================================================================
 
-@import "../global/default";
-
 @mixin reset-input {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Reduces generated CSS by 50%.

This means that compiling individual components like button is no longer
supported (at least until the structure here is reworked).

Tested with Server & NC.

Known issue: file naming. At this point, everything except 'all' should really be a partial, but I think that's academic in terms of generated output. I can follow up with another PR for that, but would like to get the core issue solved and avoid conflicts with the other outstanding branches.

Fixes #41.