### PR TITLE
Add BEM mixins to ordering whitelist

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -9,7 +9,14 @@ rules:
   placeholder-in-extend: 1
 
   # Mixins
-  mixins-before-declarations: 1
+  mixins-before-declarations:
+    - 1
+    -
+      exclude:
+        - block
+        - element
+        - modifier
+        - breakpoint
 
   # Line Spacing
   one-declaration-per-line: 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-canvas-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Styles and React components for the Network Canvas project",
   "main": "components/index.js",
   "engines": {


### PR DESCRIPTION
This adds the [bem naming helpers](https://github.com/codaco/Network-Canvas-UI/blob/master/styles/global/core/_bem.scss) to the whitelist (which includes `breakpoint` by default) for appearing after declarations in source.

I find the element & modifier mixins more readable than `__`/`--`, and they often must come after the base definition.

[Example use](https://github.com/codaco/Server/blob/master/src/renderer/styles/components/_tab_bar.scss#L4).

This is the only rule customization Server has after updating to 2.0.0.