### PR TITLE
Use input.value rather than expecting input.checked

### DIFF
--- a/components/Fields/Checkbox.js
+++ b/components/Fields/Checkbox.js
@@ -44,13 +44,17 @@ class Checkbox extends PureComponent {
           <input
             className="form-field-checkbox__input"
             id={this.id}
+            // input.checked is only provided by redux form if type="checkbox" or type="radio" is
+            // provided to <Field />, so for the case that it isn't we can rely on the more reliable
+            // input.value
+            checked={!!input.value}
             {...input}
             {...rest}
             type="checkbox"
           />
           <div className="form-field-checkbox__checkbox" />
           <div className="form-field-checkbox__label">
-            {label || this.props.input.value}
+            {label || input.value}
           </div>
         </div>
       </label>

--- a/components/Fields/Radio.js
+++ b/components/Fields/Radio.js
@@ -44,12 +44,16 @@ class Radio extends PureComponent {
           type="radio"
           className="form-field-radio__input"
           id={this.id}
+          // input.checked is only provided by redux form if type="checkbox" or type="radio" is
+          // provided to <Field />, so for the case that it isn't we can rely on the more reliable
+          // input.value
+          checked={!!input.value}
           {...input}
           {...rest}
         />
         <div className="form-field-radio__radio" />
         <div className="form-field-radio__label">
-          {label || this.props.input.value}
+          {label || input.value}
         </div>
       </label>
     );


### PR DESCRIPTION
`input.checked` is only provided by redux form if `type="checkbox"` or `type="radio"` is provided to `<Field />`, so for the case that it isn't we can rely on the more reliable `input.value`, which is what redux-form aliases under the hood.

Resolves https://github.com/codaco/Architect/issues/132