### PR TITLE
Fix sass-lint warnings and clarify dependencies

### DIFF
--- a/styles/components/form/fields/_checkbox-group.scss
+++ b/styles/components/form/fields/_checkbox-group.scss
@@ -4,15 +4,17 @@ $component-name: form-field-checkbox-group;
   @include form-field;
   display: block;
 
-  &__option:last-child {
-    margin: 0;
+  &__option {
+    &:last-child {
+      margin: 0;
+    }
   }
 
   &__error {
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/components/form/fields/_radio-group.scss
+++ b/styles/components/form/fields/_radio-group.scss
@@ -8,7 +8,7 @@ $component-name: form-field-radio-group;
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/components/form/fields/_text.scss
+++ b/styles/components/form/fields/_text.scss
@@ -4,7 +4,7 @@ $module-name: form-field-text;
   @include form-field;
   display: block;
   position: relative;
-  padding: 0.5em 1em;
+  padding: .5em 1em;
 
   &__input {
     @include typography('copy-large', font-size);
@@ -28,7 +28,7 @@ $module-name: form-field-text;
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/components/form/fields/_textarea.scss
+++ b/styles/components/form/fields/_textarea.scss
@@ -18,7 +18,7 @@ $component-name: form-fields-textarea;
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/components/form/fields/_toggle-button-group.scss
+++ b/styles/components/form/fields/_toggle-button-group.scss
@@ -12,7 +12,7 @@ $component-name: form-field-togglebutton-group;
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/components/form/fields/_toggle-button.scss
+++ b/styles/components/form/fields/_toggle-button.scss
@@ -22,7 +22,7 @@ $component-name: form-field-togglebutton;
     z-index: 0;
     font-weight: 500;
     text-align: center;
-    padding: 0.5rem;
+    padding: .5rem;
 
     &::before {
       position: absolute;

--- a/styles/components/form/fields/_toggle.scss
+++ b/styles/components/form/fields/_toggle.scss
@@ -60,7 +60,7 @@ $border-space: 3px;
     opacity: 0;
     max-height: 0;
     color: var(--error);
-    margin: unit(.5) 0 unit(.5) 0;
+    margin: unit(.5) 0;
     transition: opacity var(--animation-easing) var(--animation-duration-standard),
     max-height var(--animation-easing) var(--animation-duration-standard);
   }

--- a/styles/global/_default.scss
+++ b/styles/global/_default.scss
@@ -188,9 +188,9 @@ $system-font-stack: 'system-ui', sans-serif;
   --drop-shadow-color: #{transparentize(rgb(22, 21, 43), .25)};
 
   // Inputs
-  --input-background: rgba(0, 0, 0, .33);
-  --input-label: rgba(255, 255, 255, 1);
-  --input-placeholder: rgba(255, 255, 255, .25);
+  --input-background: #{transparentize(rgb(0, 0, 0), .67)};
+  --input-label: #{transparentize(rgb(255, 255, 255), 0)};
+  --input-placeholder: #{transparentize(rgb(255, 255, 255), .75)};
 
   --modal-overlay: #{transparentize(rgb(0, 0, 0), .2)};
   --modal-window-box-shadow: #{transparentize(rgb(22, 21, 43), .25)};


### PR DESCRIPTION
Fix most warnings from sass-lint. There's still an [`!important` declaration](https://github.com/codaco/Network-Canvas-UI/blob/1b9d988/styles/components/form/fields/_text.scss#L49); I don't know if that should be silenced or fixed.

[Edit: I removed the peerDependencies change for now as it breaks CI.]