### PR TITLE
Warn when Icon called with invalid name

### DIFF
--- a/components/Icon.js
+++ b/components/Icon.js
@@ -35,7 +35,10 @@ class Icon extends Component {
 
     const IconComponent = icons(name);
 
-    if (!IconComponent) { return null; }
+    if (!IconComponent) {
+      console.warn('Invalid icon name:', name); // eslint-disable-line no-console
+      return null;
+    }
 
     return (
       <IconComponent


### PR DESCRIPTION
Resolves #52.

This adds a warning when Icon (or, by extension, Button) is called with an incorrect name. We could instead use PropTypes.oneOf, but that feels a bit heavy.