### PR TITLE
tweak modal overlay background color

### DIFF
--- a/components/Transitions/Drop.js
+++ b/components/Transitions/Drop.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 import anime from 'animejs';
-import { getCSSVariableAsNumber } from '../../utils/CSSVariables';
+import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
 const appear = {
-  translateY: ['-100vh', 0],
+  translateY: ['-20vh', 0],
   elasticity: 0,
-  easing: 'easeInOutQuad',
+  easing: getCSSVariableAsObject('--animation-easing-js'),
   duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
 };
 

--- a/styles/components/_dialog.scss
+++ b/styles/components/_dialog.scss
@@ -2,7 +2,7 @@
   max-width: 50rem;
   background: var(--modal-main-panel);
   color: var(--text-light);
-  box-shadow: 0 0 0.25rem 0 var(--modal-window-box-shadow);
+  box-shadow: 0 0 4rem 0 var(--modal-window-box-shadow);
   position: relative;
   border-color: var(--primary);
   border-style: solid;

--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -14,6 +14,10 @@
     width: 100%;
     height: 100%;
     background-color: var(--modal-overlay);
+    @supports (backdrop-filter: blur(.75rem)) {
+      background: var(--modal-overlay); //sass-lint:disable-line no-color-literals
+      backdrop-filter: blur(.75rem);
+    }
   }
 
   &__content {

--- a/styles/global/_default.scss
+++ b/styles/global/_default.scss
@@ -197,7 +197,7 @@ $system-font-stack: 'system-ui', sans-serif;
   --input-label: #{transparentize(rgb(255, 255, 255), 0)};
   --input-placeholder: #{transparentize(rgb(255, 255, 255), 0.75)};
 
-  --modal-overlay: #{transparentize(rgb(0, 0, 0), 0.2)};
+  --modal-overlay: #{transparentize(rgb(39, 32, 76), 0.26)};
   --modal-window-box-shadow: #{transparentize(rgb(22, 21, 43), 0.25)};
 
   --panel-selected-node-bg-color: #{transparentize(rgb(255, 255, 255), 0.95)};

--- a/utils/__mocks__/CSSVariables.js
+++ b/utils/__mocks__/CSSVariables.js
@@ -5,8 +5,17 @@ const mockCSSVariables = {
   '--color-mustard': '#117733',
   '--color-sea-green': '#223344',
   '--white': '#fff',
-  '--animation-duration-slow-ms': '300',
-  '--animation-duration-standard-ms': '100',
+  '--ring': '#995522',
+  '--background': '#227733',
+  '--animation-scale-factor': 1,
+  '--animation-duration-fast': `${(1 * 0.3)}s`,
+  '--animation-duration-fast-ms': 1000 * 0.3,
+  '--animation-duration-standard': `${(1 * 0.5)}s`,
+  '--animation-duration-standard-ms': 1000 * 0.5,
+  '--animation-duration-slow': `${(1 * 1)}s`,
+  '--animation-duration-slow-ms': 1000 * 1,
+  '--animation-easing': 'cubic-bezier(0.4, 0, 0.2, 1)',
+  '--animation-easing-js': '[0.4, 0, 0.2, 1]',
 };
 
 const getCSSVariable = (cssVariableName) => {


### PR DESCRIPTION
This PR tweaks modal overlay styles

- Adjusts background color
- Adjusts the transition for the `Drop` preset