### PR TITLE
fix node rendering corruption on iOS

### DIFF
--- a/components/Node.js
+++ b/components/Node.js
@@ -33,7 +33,7 @@ class Node extends Component {
     const nodeFlashColor = `var(--${color}--dark)`;
 
     const label = this.props.label;
-    // filter: drop-shadow(0 0.25rem 0 rgba(0, 0, 0, 0.25));
+
     return (
       <div className={classes}>
         <svg

--- a/components/Node.js
+++ b/components/Node.js
@@ -33,25 +33,29 @@ class Node extends Component {
     const nodeFlashColor = `var(--${color}--dark)`;
 
     const label = this.props.label;
-
+    // filter: drop-shadow(0 0.25rem 0 rgba(0, 0, 0, 0.25));
     return (
       <div className={classes}>
         <svg
-          viewBox="-1.2 -1.2 2.4 2.4"
+          viewBox="0 0 500 500"
           xmlns="http://www.w3.org/2000/svg"
-          width="100"
-          height="100"
           className="node__node"
+          preserveAspectRatio="xMidYMid meet"
         >
-          <circle vectorEffect="non-scaling-stroke" cx="0" cy="0" r="1" className="node__node-outer-trim" />
-          <circle cx="0" cy="0" r="1" fill={nodeBaseColor} className="node__node-base" />
-          <path
-            className="node__node-flash"
-            d="M -1 0 A 0.2,0.2 0 1,1 1,0"
-            fill={nodeFlashColor}
-            transform="rotate(135)"
-          />
-          <circle vectorEffect="non-scaling-stroke" cx="0" cy="0" r="1" className="node__node-trim" />
+          <filter id="shadow">
+            <feDropShadow dx="0" dy="20" floodColor="#000000" floodOpacity="0.15" stdDeviation="0" />
+          </filter>
+          <g filter="url(#shadow)">
+            <circle cx="250" cy="250" r="250" className="node__node-outer-trim" />
+            <circle cx="250" cy="250" r="200" fill={nodeBaseColor} className="node__node-base" />
+            <path
+              d="m50,250 a1,1 0 0,0 400,0"
+              fill={nodeFlashColor}
+              className="node__node-flash"
+              transform="rotate(-35 250 250)"
+            />
+            <circle cx="250" cy="250" r="200" className="node__node-trim" />
+          </g>
         </svg>
         <div className="node__label">
           <div

--- a/styles/components/_node.scss
+++ b/styles/components/_node.scss
@@ -8,7 +8,7 @@
   }
 
   50% {
-    transform: scale(1.1);
+    transform: scale(1);
   }
 
   100% {
@@ -17,21 +17,18 @@
 }
 
 .node {
-  cursor: pointer;
+  display: inline-block;
   position: relative;
-  overflow: visible;
-  margin: 0;
-  font-size: var(--base-node-size);
   width: 1em;
-  height: 1em;
-  //sass-lint:disable no-color-literals
-  filter: drop-shadow(0 0.25rem 0 rgba(0, 0, 0, 0.25));
-  display: inline-flex;
+  font-size: var(--base-node-size);
+  padding-bottom: 100%;
+  vertical-align: middle;
 
   &__node {
-    width: 100%;
-    height: 100%;
+    display: inline-block;
     position: absolute;
+    top: 0;
+    left: 0;
     overflow: visible;
   }
 
@@ -48,14 +45,12 @@
   &__node-trim {
     fill: transparent;
     stroke: transparent;
-    stroke-width: 3px;
+    stroke-width: 0.75rem;
     transition: stroke var(--animation-duration-standard) ease-in-out;
   }
 
   &__node-outer-trim {
     fill: transparent;
-    stroke: transparent;
-    stroke-width: 1.2rem;
 
   }
 
@@ -121,7 +116,7 @@
     }
 
     .node__node-outer-trim {
-      stroke: var(--node-outer-trim-stroke);
+      fill: var(--node-outer-trim-stroke);
       animation: bounce var(--animation-duration-standard) ease-in-out;
     }
   }
@@ -132,7 +127,8 @@
     }
 
     .node__node-outer-trim {
-      stroke: var(--node-outer-trim-stroke);
+      fill: var(--node-outer-trim-stroke);
+      transform-origin: 250px 250px;
       animation: linking var(--animation-duration-slow) ease-in-out infinite;
     }
 


### PR DESCRIPTION
This PR fixes node rendering glitchyness/corruption by removing the CSS filter drop shadow, and applying the effect with an SVG filter.

It also fixes a clipping issue with the selected and linking states.