### PR TITLE
adds hard error when accessing CSS variables before all resources are loaded

### DIFF
--- a/components/Transitions/Drop.js
+++ b/components/Transitions/Drop.js
@@ -4,25 +4,28 @@ import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
-const appear = {
-  translateY: ['-20vh', 0],
-  elasticity: 0,
-  easing: getCSSVariableAsObject('--animation-easing-js'),
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-};
+const Drop = ({ children, ...props }) => {
+  const appear = {
+    translateY: ['-20vh', 0],
+    elasticity: 0,
+    easing: getCSSVariableAsObject('--animation-easing-js'),
+    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+  };
 
-const Drop = ({ children, ...props }) => (
-  <Transition
-    mountOnEnter
-    unmountOnExit
-    appear
-    timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
-    onEntering={el => anime({ targets: el, ...appear })}
-    {...props}
-  >
-    { children }
-  </Transition>
-);
+  return (
+    <Transition
+      mountOnEnter
+      unmountOnExit
+      appear
+      timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
+      onEntering={el => anime({ targets: el, ...appear })}
+      {...props}
+    >
+      { children }
+    </Transition>
+  );
+}
+
 
 Drop.propTypes = {
   children: PropTypes.any,

--- a/components/Transitions/Drop.js
+++ b/components/Transitions/Drop.js
@@ -24,7 +24,7 @@ const Drop = ({ children, ...props }) => {
       { children }
     </Transition>
   );
-}
+};
 
 
 Drop.propTypes = {

--- a/components/Transitions/Fade.js
+++ b/components/Transitions/Fade.js
@@ -4,33 +4,36 @@ import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsNumber } from '../../utils/CSSVariables';
 
-const appear = {
-  opacity: [0, 1],
-  elasticity: 0,
-  easing: 'easeInOutQuad',
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-};
+const Fade = ({ children, ...props }) => {
+  const appear = {
+    opacity: [0, 1],
+    elasticity: 0,
+    easing: 'easeInOutQuad',
+    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+  };
+  
+  const disappear = {
+    opacity: [1, 0],
+    elasticity: 0,
+    easing: 'easeInOutQuad',
+    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+  };
 
-const disappear = {
-  opacity: [1, 0],
-  elasticity: 0,
-  easing: 'easeInOutQuad',
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-};
+  return (
+    <Transition
+      mountOnEnter
+      unmountOnExit
+      appear
+      timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
+      onEntering={el => anime({ targets: el, ...appear })}
+      onExiting={el => anime({ targets: el, ...disappear })}
+      {...props}
+    >
+      { children }
+    </Transition>
+  )
 
-const Fade = ({ children, ...props }) => (
-  <Transition
-    mountOnEnter
-    unmountOnExit
-    appear
-    timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
-    onEntering={el => anime({ targets: el, ...appear })}
-    onExiting={el => anime({ targets: el, ...disappear })}
-    {...props}
-  >
-    { children }
-  </Transition>
-);
+};
 
 Fade.propTypes = {
   children: PropTypes.any,

--- a/components/Transitions/Fade.js
+++ b/components/Transitions/Fade.js
@@ -11,7 +11,7 @@ const Fade = ({ children, ...props }) => {
     easing: 'easeInOutQuad',
     duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
   };
-  
+
   const disappear = {
     opacity: [1, 0],
     elasticity: 0,
@@ -31,8 +31,7 @@ const Fade = ({ children, ...props }) => {
     >
       { children }
     </Transition>
-  )
-
+  );
 };
 
 Fade.propTypes = {

--- a/utils/CSSVariables.js
+++ b/utils/CSSVariables.js
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash';
 
 const CSSVariable = (variableName) => {
   if (document.readyState !== 'complete') {
+    // eslint-disable-next-line no-console
     console.error('You attempted to read the value of a CSS variable before all app resources were loaded! Move calls to getCSSVariableAs* outside of the top level scope of your components.');
   }
 

--- a/utils/CSSVariables.js
+++ b/utils/CSSVariables.js
@@ -1,12 +1,16 @@
 import { isEmpty } from 'lodash';
 
 const CSSVariable = (variableName) => {
+  if (document.readyState !== "complete") {
+    console.error("You attempted to read the value of a CSS variable before all app resources were loaded! Move calls to getCSSVariableAs* outside of the top level scope of your components.");
+  }
+
   const variable = getComputedStyle(document.body)
     .getPropertyValue(variableName)
     .trim();
   if (isEmpty(variable)) {
     // eslint-disable-next-line no-console
-    console.log(`CSS variable "${variableName}" not found.`);
+    console.warn(`CSS variable "${variableName}" not found!`);
     return null;
   }
   return variable;

--- a/utils/CSSVariables.js
+++ b/utils/CSSVariables.js
@@ -1,8 +1,8 @@
 import { isEmpty } from 'lodash';
 
 const CSSVariable = (variableName) => {
-  if (document.readyState !== "complete") {
-    console.error("You attempted to read the value of a CSS variable before all app resources were loaded! Move calls to getCSSVariableAs* outside of the top level scope of your components.");
+  if (document.readyState !== 'complete') {
+    console.error('You attempted to read the value of a CSS variable before all app resources were loaded! Move calls to getCSSVariableAs* outside of the top level scope of your components.');
   }
 
   const variable = getComputedStyle(document.body)


### PR DESCRIPTION
This PR adds a hard error when accessing CSS variables before window loaded state, since doing this will cause the CSS variable value to be empty. This error can be avoided by removing calls to `getCSSVariableAs*` outside of the top level scope of a component definition, or by wrapping them within a function. 