### PR TITLE
Add a progress component

### DIFF
--- a/components/Progress.js
+++ b/components/Progress.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const isDeterminate = value => value || value === 0;
+
+/**
+ * Renders a determinate <progress> bar, or an indeterminate pseudo-progress bar.
+ *
+ * This defaults to a determinate bar with 0% progress; to render the indeterminate
+ * variant, set the prop `value={null}`.
+ */
+const Progress = ({ value, max, className, ...rest }) => (
+  isDeterminate(value) ?
+    <progress className={`progress ${className}`} max={max} value={value} {...rest} />
+    :
+    <div className={`progress progress--indeterminate ${className}`} {...rest} />
+);
+
+Progress.propTypes = {
+  className: PropTypes.string,
+  max: PropTypes.number,
+  value: PropTypes.number,
+};
+
+Progress.defaultProps = {
+  className: '',
+  max: 100,
+  value: 0,
+};
+
+export default Progress;

--- a/components/__tests__/Progress.test.js
+++ b/components/__tests__/Progress.test.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Progress from '../Progress';
+
+describe('Progress', () => {
+  it('renders a determinate progress bar', () => {
+    const subject = shallow(<Progress max={100} value={50} />);
+    const progress = subject.find('progress');
+    expect(progress).toHaveLength(1);
+    expect(progress.prop('value')).toBe(50);
+    expect(progress.prop('className')).not.toMatch('indeterminate');
+  });
+
+  it('defaults to a 0% progress bar', () => {
+    const subject = shallow(<Progress />);
+    const progress = subject.find('progress');
+    expect(progress.prop('value')).toBe(0);
+  });
+
+  it('renders an indeterminate progress bar', () => {
+    const subject = shallow(<Progress value={null} />);
+    const progress = subject.find('.progress');
+    expect(progress.prop('className')).toMatch('indeterminate');
+    expect(progress.props()).not.toHaveProperty('value');
+  });
+});

--- a/components/index.js
+++ b/components/index.js
@@ -11,6 +11,7 @@ export { default as ToggleGroup } from './Inputs/ToggleGroup';
 export { default as Node } from './Node';
 export { default as Expandable } from './Expandable';
 export { default as NarrativePanel } from './NarrativePanel';
+export { default as Progress } from './Progress';
 export { default as Spinner } from './Spinner';
 export { default as Dialog } from './Dialog';
 export { default as Modal } from './Modal';

--- a/styles/components/_all.scss
+++ b/styles/components/_all.scss
@@ -7,5 +7,6 @@
 @import 'node';
 @import 'expandable';
 @import 'narrative-panel';
-@import './dialog';
-@import './modal';
+@import 'dialog';
+@import 'modal';
+@import 'progress';

--- a/styles/components/_progress.scss
+++ b/styles/components/_progress.scss
@@ -1,0 +1,54 @@
+:root {
+  --progress-background-color: var(--color-white);
+  --progress-value-color: var(--color-sea-green);
+  --progress-indeterminate-background-color: var(--color-sea-green);
+  --progress-indeterminate-highlight-color: var(--color-sea-green--dark);
+  --progress-indeterminate-gradient-width: 100rem;
+  --progress-indeterminate-animation-duration: 2s;
+
+  --progress-height: 2.5rem;
+  --progress-border-radius: var(--progress-height);
+}
+
+@keyframes progress-bar-animation {
+  from {
+    background-position: var(--progress-indeterminate-gradient-width) 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}
+
+.progress {
+  border-radius: var(--progress-border-radius);
+  height: var(--progress-height);
+  width: 100%;
+
+  @include modifier(indeterminate) {
+    animation: progress-bar-animation var(--progress-indeterminate-animation-duration) linear infinite;
+    background-image: linear-gradient(
+      0.25turn,
+      var(--progress-indeterminate-background-color),
+      var(--progress-indeterminate-highlight-color),
+      var(--progress-indeterminate-background-color),
+    );
+    background-size: var(--progress-indeterminate-gradient-width);
+  }
+
+  &[value] { // determinate
+    // sass-lint:disable-block no-vendor-prefixes
+    // 'progress-*' is non-standard and won't be autoprefixed
+    appearance: none;
+
+    &::-webkit-progress-bar {
+      background-color: var(--progress-background-color);
+      border-radius: var(--progress-border-radius);
+    }
+
+    &::-webkit-progress-value {
+      background-color: var(--progress-value-color);
+      border-radius: var(--progress-border-radius);
+    }
+  }
+}


### PR DESCRIPTION
Resolves #66.

Styling based on [the export comp](https://user-images.githubusercontent.com/1387940/49512785-e371eb00-f886-11e8-9749-d6059a7893c9.png) from https://github.com/codaco/Server/issues/200. Config vars are exposed at `:root` scope following the convention of other components.

### Examples

Determinate (50%):
![determinate](https://user-images.githubusercontent.com/39674/50296768-33d17700-0449-11e9-9478-cae8206e6d4d.png)

Indeterminate (animates gradient sideways):
![indeterminate](https://user-images.githubusercontent.com/39674/50296800-421f9300-0449-11e9-837b-56e7ddb19f3f.png)
