### PR TITLE
Fix/toggle button state

### DIFF
--- a/components/Fields/Toggle.js
+++ b/components/Fields/Toggle.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import uuid from 'uuid';
+import Icon from '../Icon';
 
 class Toggle extends PureComponent {
   static propTypes = {
@@ -58,7 +59,6 @@ class Toggle extends PureComponent {
         <h4>
           {fieldLabel || ''}
         </h4>
-        {invalid && touched && <p className="form-field-toggle__error">{error}</p>}
         <label className={componentClasses} htmlFor={this.id}>
           <div>
             <input
@@ -77,6 +77,7 @@ class Toggle extends PureComponent {
             </div>
           </div>
         </label>
+        {invalid && touched && <div className="form-field-toggle__error"><Icon name="warning" />{error}</div>}
       </div>
     );
   }

--- a/components/Fields/ToggleButton.js
+++ b/components/Fields/ToggleButton.js
@@ -49,6 +49,7 @@ class ToggleButton extends PureComponent {
           <input
             className="form-field-togglebutton__input"
             id={this.id}
+            checked={!!this.props.input.value}
             {...input}
             {...rest}
             type="checkbox"

--- a/styles/components/form/fields/_toggle.scss
+++ b/styles/components/form/fields/_toggle.scss
@@ -1,8 +1,9 @@
+$component-name: form-field-toggle;
 $size: 2rem;
 $border: 0.05rem;
 $border-space: 0.1rem;
 
-.form-field-toggle {
+.#{$component-name} {
   display: inline-block;
   cursor: pointer;
 


### PR DESCRIPTION
Fixes #93.

This makes sure ToggleButton gets the correct value when it is not a part of a ToggleButtonGroup. It also tweaks the error for Toggle so that it's visible and following the same pattern for placement as other errors do.