### PR TITLE
refactor Appear and Drawer to correctly use getCSSVariable inside function

### DIFF
--- a/components/Transitions/Appear.js
+++ b/components/Transitions/Appear.js
@@ -4,38 +4,41 @@ import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
-const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
+const AppearTransition = ({ children, ...props }) => {
 
-const appear = () => ({
-  opacity: [0, 1],
-  scale: [0, 1],
-  elasticity: 0,
-  easing: defaultEasing,
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-});
+  const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
 
-const disappear = () => ({
-  opacity: [1, 0],
-  scale: [1, 0],
-  height: 0,
-  margin: 0,
-  elasticity: 0,
-  easing: defaultEasing,
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-});
+  const appear = () => ({
+    opacity: [0, 1],
+    scale: [0, 1],
+    elasticity: 0,
+    easing: defaultEasing,
+    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+  });
 
-const AppearTransition = ({ children, ...props }) => (
-  <Transition
-    mountOnEnter
-    unmountOnExit
-    timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
-    onEntering={el => anime({ targets: el, ...appear() })}
-    onExiting={el => anime({ targets: el, ...disappear() })}
-    {...props}
-  >
-    { children }
-  </Transition>
-);
+  const disappear = () => ({
+    opacity: [1, 0],
+    scale: [1, 0],
+    height: 0,
+    margin: 0,
+    elasticity: 0,
+    easing: defaultEasing,
+    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+  });
+
+  return (
+    <Transition
+      mountOnEnter
+      unmountOnExit
+      timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
+      onEntering={el => anime({ targets: el, ...appear() })}
+      onExiting={el => anime({ targets: el, ...disappear() })}
+      {...props}
+    >
+      { children }
+    </Transition>
+  );
+};
 
 AppearTransition.propTypes = {
   children: PropTypes.any.isRequired,

--- a/components/Transitions/Appear.js
+++ b/components/Transitions/Appear.js
@@ -5,7 +5,6 @@ import anime from 'animejs';
 import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
 const AppearTransition = ({ children, ...props }) => {
-
   const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
 
   const appear = () => ({

--- a/components/Transitions/Appear.js
+++ b/components/Transitions/Appear.js
@@ -6,32 +6,33 @@ import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSV
 
 const AppearTransition = ({ children, ...props }) => {
   const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
+  const standardDuration = getCSSVariableAsNumber('--animation-duration-standard-ms');
 
-  const appear = () => ({
+  const appear = {
     opacity: [0, 1],
     scale: [0, 1],
     elasticity: 0,
     easing: defaultEasing,
-    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-  });
+    duration: standardDuration,
+  };
 
-  const disappear = () => ({
+  const disappear = {
     opacity: [1, 0],
     scale: [1, 0],
     height: 0,
     margin: 0,
     elasticity: 0,
     easing: defaultEasing,
-    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-  });
+    duration: standardDuration,
+  };
 
   return (
     <Transition
       mountOnEnter
       unmountOnExit
-      timeout={getCSSVariableAsNumber('--animation-duration-standard-ms')}
-      onEntering={el => anime({ targets: el, ...appear() })}
-      onExiting={el => anime({ targets: el, ...disappear() })}
+      timeout={standardDuration}
+      onEntering={el => anime({ targets: el, ...appear })}
+      onExiting={el => anime({ targets: el, ...disappear })}
       {...props}
     >
       { children }

--- a/components/Transitions/Drawer.js
+++ b/components/Transitions/Drawer.js
@@ -5,7 +5,6 @@ import anime from 'animejs';
 import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
 const FolderTransition = ({ children, ...props }) => {
-
   const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
 
   const appear = () => ({

--- a/components/Transitions/Drawer.js
+++ b/components/Transitions/Drawer.js
@@ -6,33 +6,35 @@ import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSV
 
 const FolderTransition = ({ children, ...props }) => {
   const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
+  const standardDuration = getCSSVariableAsNumber('--animation-duration-standard-ms');
+  const slowDuration = getCSSVariableAsNumber('--animation-duration-slow-ms');
 
-  const appear = () => ({
+  const appear = {
     opacity: {
       value: [0, 1],
-      duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+      duration: standardDuration,
       easing: defaultEasing,
     },
     scaleY: {
       value: [0, 1],
-      duration: getCSSVariableAsNumber('--animation-duration-slow-ms'),
+      duration: slowDuration,
       easing: defaultEasing,
     },
-  });
+  };
 
-  const disappear = () => ({
+  const disappear = {
     opacity: 0,
     scaleY: 0,
     margin: 0,
     maxHeight: 0,
-    duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-  });
+    duration: standardDuration,
+  };
 
   return (
     <Transition
       mountOnEnter
       unmountOnExit
-      timeout={getCSSVariableAsNumber('--animation-duration-slow-ms')}
+      timeout={slowDuration}
       onEntering={
         (el) => {
           const { height } = el.getBoundingClientRect();
@@ -44,9 +46,9 @@ const FolderTransition = ({ children, ...props }) => {
             maxHeight: {
               value: [0, `${height}px`],
               easing: 'easeInOutQuad',
-              duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+              duration: standardDuration,
             },
-            ...appear(),
+            ...appear,
           });
         }
       }
@@ -56,7 +58,7 @@ const FolderTransition = ({ children, ...props }) => {
             targets: el,
             elasticity: 0,
             easing: 'easeInOutQuad',
-            ...disappear(),
+            ...disappear,
           });
         }
       }

--- a/components/Transitions/Drawer.js
+++ b/components/Transitions/Drawer.js
@@ -4,66 +4,69 @@ import { Transition } from 'react-transition-group';
 import anime from 'animejs';
 import { getCSSVariableAsNumber, getCSSVariableAsObject } from '../../utils/CSSVariables';
 
-const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
+const FolderTransition = ({ children, ...props }) => {
 
-const appear = () => ({
-  opacity: {
-    value: [0, 1],
+  const defaultEasing = getCSSVariableAsObject('--animation-easing-js');
+
+  const appear = () => ({
+    opacity: {
+      value: [0, 1],
+      duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+      easing: defaultEasing,
+    },
+    scaleY: {
+      value: [0, 1],
+      duration: getCSSVariableAsNumber('--animation-duration-slow-ms'),
+      easing: defaultEasing,
+    },
+  });
+
+  const disappear = () => ({
+    opacity: 0,
+    scaleY: 0,
+    margin: 0,
+    maxHeight: 0,
     duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-    easing: defaultEasing,
-  },
-  scaleY: {
-    value: [0, 1],
-    duration: getCSSVariableAsNumber('--animation-duration-slow-ms'),
-    easing: defaultEasing,
-  },
-});
+  });
 
-const disappear = () => ({
-  opacity: 0,
-  scaleY: 0,
-  margin: 0,
-  maxHeight: 0,
-  duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-});
+  return (
+    <Transition
+      mountOnEnter
+      unmountOnExit
+      timeout={getCSSVariableAsNumber('--animation-duration-slow-ms')}
+      onEntering={
+        (el) => {
+          const { height } = el.getBoundingClientRect();
 
-const FolderTransition = ({ children, ...props }) => (
-  <Transition
-    mountOnEnter
-    unmountOnExit
-    timeout={getCSSVariableAsNumber('--animation-duration-slow-ms')}
-    onEntering={
-      (el) => {
-        const { height } = el.getBoundingClientRect();
-
-        anime({
-          targets: el,
-          elasticity: 0,
-          easing: 'easeInOutQuad',
-          maxHeight: {
-            value: [0, `${height}px`],
+          anime({
+            targets: el,
+            elasticity: 0,
             easing: 'easeInOutQuad',
-            duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
-          },
-          ...appear(),
-        });
+            maxHeight: {
+              value: [0, `${height}px`],
+              easing: 'easeInOutQuad',
+              duration: getCSSVariableAsNumber('--animation-duration-standard-ms'),
+            },
+            ...appear(),
+          });
+        }
       }
-    }
-    onExiting={
-      (el) => {
-        anime({
-          targets: el,
-          elasticity: 0,
-          easing: 'easeInOutQuad',
-          ...disappear(),
-        });
+      onExiting={
+        (el) => {
+          anime({
+            targets: el,
+            elasticity: 0,
+            easing: 'easeInOutQuad',
+            ...disappear(),
+          });
+        }
       }
-    }
-    {...props}
-  >
-    { children }
-  </Transition>
-);
+      {...props}
+    >
+      { children }
+    </Transition>
+  );
+};
 
 FolderTransition.propTypes = {
   children: PropTypes.any.isRequired,


### PR DESCRIPTION
Fixes some small console errors by refactoring Appear and Drawer to correctly use the JS CSS variable fetch utilities inside of their function definition.