### PR TITLE
fix height on initial rendering

### DIFF
--- a/components/Transitions/Drawer.js
+++ b/components/Transitions/Drawer.js
@@ -20,13 +20,18 @@ const FolderTransition = ({ children, ...props }) => {
       duration: slowDuration,
       easing: defaultEasing,
     },
+    height: {
+      value: [0, '100%'],
+      duration: slowDuration,
+      easing: defaultEasing,
+    },
   };
 
   const disappear = {
     opacity: 0,
     scaleY: 0,
     margin: 0,
-    maxHeight: 0,
+    height: 0,
     duration: standardDuration,
   };
 


### PR DESCRIPTION
Fixes disappearing for initial rendering. This is an issue seen on Server, the export screen, when swapping which export type displays initially. With CSV as the default, selecting Graphml doesn't animate the height on disappear the first time.