### PR TITLE
prefer placeholder over label for text input, and allow search type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "type": "module",

--- a/src/components/Fields/Text.js
+++ b/src/components/Fields/Text.js
@@ -15,6 +15,7 @@ class TextInput extends PureComponent {
     type: PropTypes.oneOf([
       'text',
       'number',
+      'search',
     ]),
     placeholder: PropTypes.string,
     hidden: PropTypes.bool,
@@ -70,7 +71,7 @@ class TextInput extends PureComponent {
             id={this.id}
             name={input.name}
             className="form-field form-field-text form-field-text__input"
-            placeholder={label || placeholder}
+            placeholder={placeholder || label}
             autoFocus={autoFocus} // eslint-disable-line
             type={type}
             {...input}

--- a/src/components/Fields/TextArea.js
+++ b/src/components/Fields/TextArea.js
@@ -78,7 +78,7 @@ class TextArea extends PureComponent {
           <textarea
             id={this.id}
             className="form-field form-field-text form-field-text--area form-field-text__input"
-            placeholder={label || placeholder}
+            placeholder={placeholder || label}
             autoFocus={autoFocus} // eslint-disable-line
             type={type}
             {...input}


### PR DESCRIPTION
This PR changes text inputs to use placeholder over label, rather than label over placeholder.

It also adds "search" as a valid text input type, which fixes #120.