### PR TITLE
Feature/better dialog overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "type": "module",

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -20,15 +20,15 @@ const Dialog = ({ children, type, icon, show, options, title, message, onBlur, c
         <div className="dialog__main-content">
           <h2 className="dialog__main-title">{title}</h2>
           {message}
+          { children &&
+          <div className="dialog__additional-content">
+            <div className="dialog__additional-box">
+              {children}
+            </div>
+          </div>
+          }
         </div>
       </div>
-      { children &&
-        <div className="dialog__additional-content">
-          <div className="dialog__additional-box">
-            {children}
-          </div>
-        </div>
-      }
       <footer className="dialog__footer">
         {options}
       </footer>

--- a/src/styles/components/_dialog.scss
+++ b/src/styles/components/_dialog.scss
@@ -1,29 +1,30 @@
 .dialog {
-  max-width: 50rem;
+  max-width: 60rem;
+  display: flex;
+  flex-direction: column;
   background: var(--modal-background);
   color: var(--text-light);
   box-shadow: 0 0 4rem 0 var(--modal-window-box-shadow);
-  position: relative;
   border-color: var(--primary);
   border-style: solid;
   border-width: 0;
   border-left-width: 0.5rem;
   border-radius: 0.75rem;
   max-height: 80vh;
-  overflow-x: hidden;
-  overflow-y: auto;
 
   &__main {
+    flex: 1 1 100%;
     display: flex;
+    flex-direction: row;
     width: 100%;
-    padding: 2rem 3rem 0;
+    padding: unit(4) unit(4) 0;
 
     &-content {
       order: 1;
-      flex-grow: 1;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
+      overflow-y: auto;
+      flex: 1 1 auto;
+      height: 100%;
+      padding: 0 unit(4);
     }
 
     &-title {
@@ -34,9 +35,10 @@
 
     &-icon {
       order: 1;
-      flex: 0 0 10rem;
+      flex: 0 0 8rem;
       display: flex;
       align-items: center;
+      justify-content: center;
 
       .icon {
         height: 7.5rem;
@@ -73,6 +75,7 @@
   &__footer {
     margin: 2rem 3rem;
     text-align: right;
+    flex: 1 0 auto;
 
     .button {
       &:last-child {

--- a/src/styles/components/_dialog.scss
+++ b/src/styles/components/_dialog.scss
@@ -50,14 +50,13 @@
   &__additional {
 
     &-box {
-      height: 15rem;
+      max-height: 15rem;
       padding: 1.5rem;
       margin-top: 1.5rem;
       background: var(--background);
       user-select: initial;
       overflow-y: auto;
       overflow-x: hidden;
-      margin: 1.5rem 3rem;
       border-radius: var(--border-radius);
 
       h1,

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -216,6 +216,9 @@ $system-font-stack: 'system-ui', sans-serif;
   --heading-font-family: #{$netcanvas-font-stack};
   --body-font-family: #{$system-font-stack};
 
+  // Default border radius
+  --border-radius: .75rem;
+
   // each item in color map
   @each $name, $color in $-color-map {
     #{'--'}color-#{$name}: #{'rgb('}#{$color}#{')'};

--- a/src/styles/global/_default.scss
+++ b/src/styles/global/_default.scss
@@ -219,6 +219,9 @@ $system-font-stack: 'system-ui', sans-serif;
   // Default border radius
   --border-radius: .75rem;
 
+  // Link color
+  --link-color: var(--color-neon-coral);
+
   // each item in color map
   @each $name, $color in $-color-map {
     #{'--'}color-#{$name}: #{'rgb('}#{$color}#{')'};
@@ -289,6 +292,10 @@ $system-font-stack: 'system-ui', sans-serif;
 html {
   font-family: var(--body-font-family);
   font-size: var(--base-font-size);
+}
+
+a {
+  color: var(--link-color);
 }
 
 // Headings


### PR DESCRIPTION
This PR changes the structure of the dialog component in a (hopefully!) non-destructive way.

Current behaviour:
- Entire dialog scrolls when content overflows.
- Buttons not visible in this scenario
- Icon misaligned

New behaviour:
- Only dialog content is scrollable
- Buttons are always visible, even with long dialog content
- Icon is always aligned centrally

Also changed:
- Additional content moved inside of dialog content so that it correctly causes scrolling when it overflows
- Dialog width increased
- Default link color CSS variable
- Border radius CSS variable (copied from NC - was being used in UI components, and this caused incorrect rendering in Architect and Server)